### PR TITLE
Report update failures.

### DIFF
--- a/lib/Bot/BasicBot/Pluggable/Module/Nagios.pm
+++ b/lib/Bot/BasicBot/Pluggable/Module/Nagios.pm
@@ -233,6 +233,15 @@ sub tick {
     return if (time - $last_polled < $poll_delay);
     $last_polled = time;
 
+    # OK, time to poll Nagios and report stuff.
+    $self->check_nagios;
+}
+
+sub check_nagios {
+    my ($self) = @_;
+
+    my $repeat_delay = $self->get('repeat_delay') || 15 * 60;
+
     # Find out what statuses we should report; do this here, so it's ready for
     # use in the loop later (we don't want to re-do it for every service :) )
     my $report_statuses = $self->get('report_statuses')

--- a/lib/Bot/BasicBot/Pluggable/Module/Nagios.pm
+++ b/lib/Bot/BasicBot/Pluggable/Module/Nagios.pm
@@ -280,7 +280,7 @@ sub check_nagios {
                 for my $channel (@{ $instance->{channels} }) {
                     $self->tell(
                         $channel,
-                        "NAGIOS: Update failure for$instance_name",
+                        "NAGIOS: Update failure for $instance_name",
                     );
                 }
             }

--- a/lib/Bot/BasicBot/Pluggable/Module/Nagios.pm
+++ b/lib/Bot/BasicBot/Pluggable/Module/Nagios.pm
@@ -253,7 +253,9 @@ sub tick {
         # easily look up whether a host is down in order to skip reporting
         # services
         $ns->host_state(14); # All hosts, including OK ones
-        my @all_hosts = $ns->get_host_status;
+        my @all_hosts;
+        # Nagios::Scrape will die() on error
+        eval { @all_hosts = $ns->get_host_status; };
         my %host_down  = 
             map  { $_->{host} => 1        } 
             grep { $_->{status} eq 'DOWN' }

--- a/lib/Bot/BasicBot/Pluggable/Module/Nagios.pm
+++ b/lib/Bot/BasicBot/Pluggable/Module/Nagios.pm
@@ -80,12 +80,22 @@ sub told {
         }
         my @channels = split /\s+|,/, $channel_list;
         my $instances = $self->get('instances') || [];
-        push @$instances, {
+
+        my $instance = {
             url      => $url,
             user     => $user,
             pass     => $pass,
             channels => \@channels,
         };
+
+        my $poll_result = $self->poll_instance($instance);
+        if ($poll_result->{error}) {
+            my $instance_name = $self->instance_name($instance);
+            return "Failed to poll $instance_name - "
+                . $poll_result->{error} . " - not adding it";
+        }
+
+        push @$instances, $instance;
         $self->set('instances' => $instances);
         return "OK, added Nagios instance to monitor";
     }


### PR DESCRIPTION
If report_statuses includes UPDATE_FAIL, then announce failures to fetch/scrape
the Nagios status page, rather than staying silent and making it seem that all
is fine when potentially it isn't.

TODO: maybe add some robustification, e.g. auto-retry and only announce the
failure if a couple of attempts in a row failed, to avoid potential for spurious
noise.